### PR TITLE
Features/bugs

### DIFF
--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -88,12 +88,11 @@ export default function DocsPage() {
         <article>
           <h1 className="text-2xl md:text-3xl font-bold mb-4">
             {selectedTip.title}
-          </h1>
+          </h1>{" "}
           <Badge variant="secondary" className="mb-4">
             {selectedTip.category}
           </Badge>
           <p className="text-base md:text-lg mb-6">{selectedTip.description}</p>
-
           <section>
             <h2 className="text-xl md:text-2xl font-semibold mb-4">
               Code Example
@@ -102,7 +101,6 @@ export default function DocsPage() {
               <code className="text-sm">{selectedTip.code}</code>
             </pre>
           </section>
-
           {selectedTip.detailedExplanation && (
             <section>
               <h2 className="text-xl md:text-2xl font-semibold mb-4">
@@ -114,7 +112,6 @@ export default function DocsPage() {
               </div>
             </section>
           )}
-
           {selectedTip.bestPractices &&
             selectedTip.bestPractices.length > 0 && (
               <section>

--- a/app/tips/page.tsx
+++ b/app/tips/page.tsx
@@ -1,7 +1,45 @@
-export default function Tip() {
+import Link from "next/link";
+import { typescriptTips } from "@/data/typescript-tips";
+import { Badge } from "@/components/ui/badge";
+
+export default function TipsPage() {
+  // Group tips by category
+  const tipsByCategory = typescriptTips.reduce((acc, tip) => {
+    if (!acc[tip.category]) {
+      acc[tip.category] = [];
+    }
+    acc[tip.category].push(tip);
+    return acc;
+  }, {} as Record<string, typeof typescriptTips>);
+
   return (
-    <div className="container mx-auto py-20">
-      <h2 className="text-center font-bold text-lg ">Hello there!</h2>
+    <div className="container mx-auto py-8">
+      <h1 className="text-3xl font-bold mb-6 text-[#2D1637] ">
+        TypeScript Tips Overview
+      </h1>
+      <p className="mb-8 text-lg">
+        Explore our collection of TypeScript tips, organized by category. Click
+        on a tip to see more details.
+      </p>
+
+      {Object.entries(tipsByCategory).map(([category, tips]) => (
+        <div key={category} className="mb-8">
+          <h2 className="text-2xl font-semibold mb-4">{category}</h2>
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {tips.map((tip) => (
+              <Link href={`/docs#${tip.id}`} key={tip.id} className="block">
+                <div className="border rounded-lg p-4 hover:shadow-md transition-shadow">
+                  <h3 className="text-lg font-medium mb-2 text-[#2D1637] ">
+                    {tip.title}
+                  </h3>
+                  <p className="text-sm  mb-2">{tip.description}</p>
+                  <Badge>{category}</Badge>
+                </div>
+              </Link>
+            ))}
+          </div>
+        </div>
+      ))}
     </div>
   );
 }

--- a/components/typescript-preview-modal.tsx
+++ b/components/typescript-preview-modal.tsx
@@ -54,7 +54,9 @@ export function TypeScriptPreviewModal({
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className="max-w-4xl">
         <DialogHeader>
-          <DialogTitle>Try TypeScript Code</DialogTitle>
+          <DialogTitle>
+            Try TypeScript Code
+          </DialogTitle>
         </DialogHeader>
         <div className="grid grid-cols-2 gap-4">
           <div>


### PR DESCRIPTION
This pull request includes changes to the `DocsPage`, `TipsPage`, and `TypeScriptPreviewModal` components to improve the structure and presentation of TypeScript tips. The most important changes include restructuring the `TipsPage` component to group tips by category, and making minor formatting adjustments to the `DocsPage` and `TypeScriptPreviewModal` components.

Improvements to `TipsPage`:

* [`app/tips/page.tsx`](diffhunk://#diff-2e326ddb22658f76da7b9cb4147e60f578ca85ffaa597fcbe07bc6ccbc6cb9d8L1-R42): Added imports for `Link`, `typescriptTips`, and `Badge`, and restructured the component to group tips by category and display them in a grid format.

Formatting adjustments:

* [`app/docs/page.tsx`](diffhunk://#diff-e5a522297856558b71aaa96688acdc607b02a39286625b52d1415c3f79ddb87aL91-L96): Made minor formatting adjustments to the `DocsPage` component by removing unnecessary whitespace. [[1]](diffhunk://#diff-e5a522297856558b71aaa96688acdc607b02a39286625b52d1415c3f79ddb87aL91-L96) [[2]](diffhunk://#diff-e5a522297856558b71aaa96688acdc607b02a39286625b52d1415c3f79ddb87aL105) [[3]](diffhunk://#diff-e5a522297856558b71aaa96688acdc607b02a39286625b52d1415c3f79ddb87aL117)
* [`components/typescript-preview-modal.tsx`](diffhunk://#diff-9d227b1f83c7b9734a6f61d093254d19fcf047d2736220da0051d31dd8f0e1b5L57-R59): Adjusted the formatting of the `DialogTitle` element in the `TypeScriptPreviewModal` component for better readability.