### PR TITLE
CORE: Update FAQ section text color for improved visibility

### DIFF
--- a/app/legal/faq/page.tsx
+++ b/app/legal/faq/page.tsx
@@ -66,7 +66,7 @@ export default function FAQ() {
     
       <section className="w-full max-w-6xl mx-auto px-4 py-12">
         <div id="faq" className="space-y-2 mb-8 mt-20">
-          <p className="text-emerald-500 font-medium">FAQ</p>
+          <p className="text-[#2D1637] font-medium">FAQ</p>
           <h2 className="text-3xl font-bold text-gray-900">
             Frequently Asked Questions
           </h2>


### PR DESCRIPTION
This pull request includes a small change to the `app/legal/faq/page.tsx` file. The change updates the color of the FAQ heading text.

* [`app/legal/faq/page.tsx`](diffhunk://#diff-814561af0afad4079a47983531d886b58726a050ca56fbf5c1988dcff8ed7afcL69-R69): Changed the text color of the FAQ heading from `text-emerald-500` to `text-[#2D1637]`.